### PR TITLE
Feature/winning hand strings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ const renderCards = (cards) => {
 
 const showWinningHand = (cards) => {
   hand.addCards(...cards)
-  bestHandText.textContent = `${hand.getFullName()}!`
+  bestHandText.textContent = `The best hand is ${hand.getFullName()}`
   console.log(prettyPrint(cards))
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ const renderCards = (cards) => {
 
 const showWinningHand = (cards) => {
   hand.addCards(...cards)
-  bestHandText.textContent = `You won with ${hand.getName()}!`
+  bestHandText.textContent = `${hand.getFullName()}!`
   console.log(prettyPrint(cards))
 }
 

--- a/src/scripts/hand-combinations.test.js
+++ b/src/scripts/hand-combinations.test.js
@@ -1,5 +1,5 @@
 import { getBestHand } from './hand-combinations'
-import * as card from './test-cards'
+import * as card from '../test-data/cards'
 
 describe('should find the best possible combination of 5 cards from 7 cards', () => {
   test('should identify the best hand as Three of a Kind when given 3 aces in 7 cards', () => {

--- a/src/scripts/hand.js
+++ b/src/scripts/hand.js
@@ -1,3 +1,5 @@
+import Card from './card'
+
 export default class Hand {
   rankings = [
     'High Card',
@@ -12,12 +14,29 @@ export default class Hand {
     'Royal Flush',
   ]
 
+  cardNames = [
+    '2',
+    '3',
+    '4',
+    '5',
+    '6',
+    '7',
+    '8',
+    '9',
+    '10',
+    'Jack',
+    'Queen',
+    'King',
+    'Ace',
+  ]
+
   constructor(...cards) {
     if (cards.length > 5) {
       throw Error('Hands must contain 5 or less cards')
     }
     this.cards = [...cards]
     this.score = this.getScore()
+    this.cardCounts
   }
 
   addCards(...cards) {
@@ -33,10 +52,44 @@ export default class Hand {
   empty() {
     this.cards = []
     this.score = 0
+    this.cardCounts = {}
   }
 
   getName() {
     return this.rankings[this.getRank()]
+  }
+
+  getFullName() {
+    const highCardName = this.cardNames[this.cardCounts.highCard - 2]
+    const firstPairName = this.cardNames[this.cardCounts.pairs[0] - 2]
+    const secondPairName = this.cardNames[this.cardCounts.pairs[1] - 2]
+    const tripleName = this.cardNames[this.cardCounts.threeOfAKind - 2]
+    const quadrupleName = this.cardNames[this.cardCounts.fourOfAKind - 2]
+
+    switch (this.getRank()) {
+      case 0:
+        return `${this.rankings[0]}, ${highCardName}`
+      case 1:
+        return `${this.rankings[1]} of ${firstPairName}s`
+      case 2:
+        return `${this.rankings[2]}, ${secondPairName}s over ${firstPairName}s`
+      case 3:
+        return `${this.rankings[3]}, ${tripleName}s`
+      case 4:
+        return `${highCardName}-high ${this.rankings[4]}`
+      case 5:
+        return `${highCardName}-high ${this.rankings[5]}`
+      case 6:
+        return `${this.rankings[6]}, ${tripleName}s over ${firstPairName}s`
+      case 7:
+        return `${this.rankings[7]}, ${quadrupleName}s`
+      case 8:
+        return `${highCardName}-high ${this.rankings[8]}`
+      case 9:
+        return this.rankings[9]
+      default:
+        return this.getName()
+    }
   }
 
   // Returns a value corresponding to the rankings array
@@ -48,7 +101,8 @@ export default class Hand {
   getScore() {
     if (this.cards.length === 0) return 0
 
-    const cardCounts = this.#getCounts()
+    this.cardCounts = this.#getCounts()
+    const cardCounts = this.cardCounts
     const highCard = cardCounts.highCard
 
     if (cardCounts.hasFlush && cardCounts.hasStraight) {
@@ -158,8 +212,8 @@ export default class Hand {
       cardCounts.valuesArray.push(card.value)
     })
 
-    cardCounts['highCard'] = Math.max(...cardCounts.valuesArray)
     cardCounts.valuesArray.sort((a, b) => a - b)
+    cardCounts['highCard'] = cardCounts.valuesArray.slice(-1)[0]
     if (this.cards.length === 5) {
       // Handle unique case where Ace is low in a 5-high "wheel" straight
       if (JSON.stringify(cardCounts.valuesArray) === '[2,3,4,5,14]') {

--- a/src/scripts/hand.js
+++ b/src/scripts/hand.js
@@ -218,6 +218,7 @@ export default class Hand {
       // Handle unique case where Ace is low in a 5-high "wheel" straight
       if (JSON.stringify(cardCounts.valuesArray) === '[2,3,4,5,14]') {
         cardCounts.valuesArray = [1, 2, 3, 4, 5]
+        cardCounts.highCard = 5
         cardCounts['hasStraight'] = true
       } else {
         cardCounts['hasStraight'] = this.#hasStraight(cardCounts.valuesArray)

--- a/src/scripts/hand.js
+++ b/src/scripts/hand.js
@@ -32,6 +32,7 @@ export default class Hand {
 
   empty() {
     this.cards = []
+    this.score = 0
   }
 
   getName() {
@@ -40,7 +41,7 @@ export default class Hand {
 
   // Returns a value corresponding to the rankings array
   getRank() {
-    return Math.floor(this.score / 1000000)
+    return Math.floor(this.score / 1_000_000)
   }
 
   // Returns an absolute score of a hand of any number of cards
@@ -52,39 +53,39 @@ export default class Hand {
 
     if (cardCounts.hasFlush && cardCounts.hasStraight) {
       // Royal Flush - no tiebreaker
-      if (highCard === 14) return 9000000
+      if (highCard === 14) return 9_000_000
       // Straight Flush - high card tiebreaker
-      return 8000000 + highCard
+      return 8_000_000 + highCard
     }
     // 4 of a Kind - matching cards tiebreaker, no kicker
     if (cardCounts.fourOfAKind) {
-      return 7000000 + this.#fourOfAKindTiebreaker(cardCounts)
+      return 7_000_000 + this.#fourOfAKindTiebreaker(cardCounts)
     }
     // Full House - highest trip, then highest pair
     if (cardCounts.threeOfAKind && cardCounts.pairs.length > 0) {
       return (
-        6000000 +
+        6_000_000 +
         cardCounts.threeOfAKind * Math.pow(13, 2) +
         parseInt(cardCounts.pairs[0]) * Math.pow(13, 1)
       )
     }
     // Flush - high card tiebreaker, followed by next highest card
     if (cardCounts.hasFlush) {
-      return 5000000 + this.#highCardTiebreaker(cardCounts.valuesArray)
+      return 5_000_000 + this.#highCardTiebreaker(cardCounts.valuesArray)
     }
     // Straight - high card tiebreaker
-    if (cardCounts.hasStraight) return 4000000 + highCard
+    if (cardCounts.hasStraight) return 4_000_000 + highCard
     // Three of a Kind - highest trip, then next highest cards
     if (cardCounts.threeOfAKind) {
-      return 3000000 + this.#threeOfAKindTiebreaker(cardCounts)
+      return 3_000_000 + this.#threeOfAKindTiebreaker(cardCounts)
     }
     // Two Pair - highest top pair, then highest bottom pair, then highest remaining card
     if (cardCounts.pairs.length === 2) {
-      return 2000000 + this.#twoPairTiebreaker(cardCounts)
+      return 2_000_000 + this.#twoPairTiebreaker(cardCounts)
     }
     // Pair - highest pair, then next highest cards
     if (cardCounts.pairs.length === 1) {
-      return 1000000 + this.#pairTiebreaker(cardCounts)
+      return 1_000_000 + this.#pairTiebreaker(cardCounts)
     }
     // High card - Highest card then next highest card
     return 0 + this.#highCardTiebreaker(cardCounts.valuesArray)
@@ -158,8 +159,8 @@ export default class Hand {
     })
 
     cardCounts['highCard'] = Math.max(...cardCounts.valuesArray)
+    cardCounts.valuesArray.sort((a, b) => a - b)
     if (this.cards.length === 5) {
-      cardCounts.valuesArray.sort((a, b) => a - b)
       // Handle unique case where Ace is low in a 5-high "wheel" straight
       if (JSON.stringify(cardCounts.valuesArray) === '[2,3,4,5,14]') {
         cardCounts.valuesArray = [1, 2, 3, 4, 5]

--- a/src/scripts/hand.test.js
+++ b/src/scripts/hand.test.js
@@ -390,6 +390,20 @@ describe('Maximum hand size logic', () => {
   })
 })
 
+describe('Add cards method', () => {
+  test('should update the score when a card is added', () => {
+    const highCardHand = new Hand(
+      card.kingOfSpades,
+      card.queenOfSpades,
+      card.jackOfSpades,
+      card.tenOfSpades
+    )
+    expect(highCardHand.score).toBe(30742)
+    highCardHand.addCards(card.aceOfSpades)
+    expect(highCardHand.score).toBe(9000000)
+  })
+})
+
 describe('Empty hand method', () => {
   test('should clear all cards from a hand resulting in 0 cards', () => {
     const fullHand = new Hand(
@@ -401,5 +415,6 @@ describe('Empty hand method', () => {
     )
     fullHand.empty()
     expect(fullHand.cards.length).toBe(0)
+    expect(fullHand.score).toBe(0)
   })
 })

--- a/src/scripts/hand.test.js
+++ b/src/scripts/hand.test.js
@@ -446,6 +446,6 @@ describe('Winning strings', () => {
       card.eightOfSpades,
       card.sevenOfSpades
     )
-    expect(hand.getFullName()).toBe("Jack-high Straight Flush")
+    expect(hand.getFullName()).toBe('Jack-high Straight Flush')
   })
 })

--- a/src/scripts/hand.test.js
+++ b/src/scripts/hand.test.js
@@ -1,5 +1,5 @@
 import Hand from './hand'
-import * as card from './test-cards'
+import * as card from '../test-data/cards'
 
 describe('Hand ranking logic for incomplete hands', () => {
   test('should identify "High Card" when provided any 2 cards that are not a pair', () => {
@@ -89,6 +89,19 @@ describe('Hand ranking logic for 5 card hands', () => {
     expect(hand.getName()).toBe('Straight Flush')
   })
 
+  test('should identify "Straight Flush" when an Ace is used as a low card in suited Ace, 2, 3, 4, 5', () => {
+    const hand = new Hand(
+      card.twoOfSpades,
+      card.threeOfSpades,
+      card.fourOfSpades,
+      card.fiveOfSpades,
+      card.aceOfSpades
+    )
+    expect(hand.getRank()).toBe(8)
+    expect(hand.getName()).toBe('Straight Flush')
+    expect(hand.getFullName()).toBe('5-high Straight Flush')
+  })
+
   test('should identify "Four of a Kind" when 4 cards each have the same value', () => {
     const hand = new Hand(
       card.aceOfClubs,
@@ -147,6 +160,7 @@ describe('Hand ranking logic for 5 card hands', () => {
     )
     expect(hand.getRank()).toBe(4)
     expect(hand.getName()).toBe('Straight')
+    expect(hand.getFullName()).toBe('5-high Straight')
   })
 
   test('should identify "Three of a Kind" when 5 cards contain 3 cards of the same value', () => {
@@ -416,5 +430,22 @@ describe('Empty hand method', () => {
     fullHand.empty()
     expect(fullHand.cards.length).toBe(0)
     expect(fullHand.score).toBe(0)
+    fullHand.addCards(card.twoOfClubs, card.twoOfDiamonds)
+    expect(fullHand.cards.length).toBe(2)
+    expect(fullHand.getRank()).toBe(1)
+    expect(fullHand.score).toBe(1004394)
+  })
+})
+
+describe('Winning strings', () => {
+  test('should return "Jack-high Straight Flush" when highest card in a Straight Flush is a Jack', () => {
+    const hand = new Hand(
+      card.jackOfSpades,
+      card.tenOfSpades,
+      card.nineOfSpades,
+      card.eightOfSpades,
+      card.sevenOfSpades
+    )
+    expect(hand.getFullName()).toBe("Jack-high Straight Flush")
   })
 })

--- a/src/test-data/cards.js
+++ b/src/test-data/cards.js
@@ -1,5 +1,5 @@
 // Test Card data
-import Card from './card'
+import Card from '../scripts/card'
 
 export const aceOfClubs = new Card('Ace', 'Clubs', 14, 'AC')
 export const kingOfClubs = new Card('King', 'Clubs', 13, 'KC')
@@ -32,6 +32,7 @@ export const jackOfSpades = new Card('Jack', 'Spades', 11, 'JS')
 export const tenOfSpades = new Card(10, 'Spades', 10, 'TS')
 export const nineOfSpades = new Card(9, 'Spades', 9, '9S')
 export const eightOfSpades = new Card(8, 'Spades', 8, '8S')
+export const sevenOfSpades = new Card(7, 'Spades', 7, '7S')
 export const sixOfSpades = new Card(6, 'Spades', 6, '6S')
 export const fiveOfSpades = new Card(5, 'Spades', 5, '5S')
 export const fourOfSpades = new Card(4, 'Spades', 4, '4S')


### PR DESCRIPTION
Resolves #5 and fixes a bug where a 5-high straight flush would still be considered a Royal Flush with a max score!
- [x] Return a user-friendly verbose string for each hand e.g. "Ace high", "Full House, kings over 2s", "Pair of Queens", "Three of a Kind, 9s", "7 high Straight" etc.